### PR TITLE
Use stable NextcloudKit version 5.0.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             url: "https://github.com/claucambra/NextcloudCapabilitiesKit.git",
                 .upToNextMajor(from: "2.1.2")
         ),
-        .package(url: "https://github.com/nextcloud/NextcloudKit", branch: "develop"),
+        .package(url: "https://github.com/nextcloud/NextcloudKit", from: "5.0.4"),
         .package(url: "https://github.com/realm/realm-swift.git", exact: "10.49.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0")
     ],


### PR DESCRIPTION
Stop using unstable develop branch as 5.0.4 is macOS compatible again