### PR TITLE
Handle data for each account in separate databases

### DIFF
--- a/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -34,7 +34,7 @@ public final class FilesDatabaseManager: Sendable {
         realmConfig: Realm.Configuration = Realm.Configuration.defaultConfiguration,
         account: String,
         fileProviderDataDirUrl: URL? = pathForFileProviderExtData(),
-        relativeDatabaseFolderPath: String = relativeDatabaseFolderPath,
+        relativeDatabaseFolderPath: String = relativeDatabaseFolderPath
     ) {
         Realm.Configuration.defaultConfiguration = realmConfig
 

--- a/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -21,7 +21,6 @@ fileprivate let stable1_0SchemaVersion: UInt64 = 100
 fileprivate let stable2_0SchemaVersion: UInt64 = 200 // Major change: deleted LocalFileMetadata type
 
 public final class FilesDatabaseManager: Sendable {
-    public static let shared = FilesDatabaseManager()!
 
     private static let relativeDatabaseFolderPath = "Database/"
     private static let databaseFilename = "fileproviderextdatabase.realm"

--- a/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -30,7 +30,9 @@ public final class FilesDatabaseManager: Sendable {
 
     var itemMetadatas: Results<RealmItemMetadata> { ncDatabase().objects(RealmItemMetadata.self) }
 
-    public init(realmConfig: Realm.Configuration = Realm.Configuration.defaultConfiguration) {
+    public init(
+        realmConfig: Realm.Configuration = Realm.Configuration.defaultConfiguration, account: String
+    ) {
         Realm.Configuration.defaultConfiguration = realmConfig
 
         do {
@@ -41,7 +43,7 @@ public final class FilesDatabaseManager: Sendable {
         }
     }
 
-    public convenience init?() {
+    public convenience init?(account: String) {
         let relativeDatabaseFilePath = Self.relativeDatabaseFolderPath + Self.databaseFilename
         guard let fileProviderDataDirUrl = pathForFileProviderExtData() else { return nil }
         let databasePath = fileProviderDataDirUrl.appendingPathComponent(relativeDatabaseFilePath)
@@ -90,7 +92,7 @@ public final class FilesDatabaseManager: Sendable {
             },
             objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self]
         )
-        self.init(realmConfig: config)
+        self.init(realmConfig: config, account: account)
     }
 
     func ncDatabase() -> Realm {

--- a/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
@@ -30,7 +30,9 @@ extension Enumerator {
         error: NKError?
     ) {
         let results = await self.scanRecursively(
-            Item.rootContainer(account: account, remoteInterface: remoteInterface).metadata,
+            Item.rootContainer(
+                account: account, remoteInterface: remoteInterface, dbManager: dbManager
+            ).metadata,
             account: account,
             remoteInterface: remoteInterface,
             dbManager: dbManager,

--- a/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
@@ -66,7 +66,8 @@ extension Enumerator {
                 metadata: metadata,
                 parentItemIdentifier: .trashContainer,
                 account: account,
-                remoteInterface: remoteInterface
+                remoteInterface: remoteInterface,
+                dbManager: dbManager
             )
             newTrashedItems.append(item)
 

--- a/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -44,7 +44,7 @@ public class Enumerator: NSObject, NSFileProviderEnumerator {
         enumeratedItemIdentifier: NSFileProviderItemIdentifier,
         account: Account,
         remoteInterface: RemoteInterface,
-        dbManager: FilesDatabaseManager = .shared,
+        dbManager: FilesDatabaseManager,
         domain: NSFileProviderDomain? = nil,
         fastEnumeration: Bool = true,
         listener: EnumerationListener? = nil

--- a/Sources/NextcloudFileProviderKit/Enumeration/MaterialisedEnumerationObserver.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/MaterialisedEnumerationObserver.swift
@@ -26,7 +26,7 @@ public class MaterialisedEnumerationObserver: NSObject, NSFileProviderEnumeratio
 
     public required init(
         ncKitAccount: String,
-        dbManager: FilesDatabaseManager = FilesDatabaseManager.shared,
+        dbManager: FilesDatabaseManager,
         completionHandler: @escaping (_ deletedOcIds: Set<String>) -> Void
     ) {
         self.ncKitAccount = ncKitAccount

--- a/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -421,7 +421,7 @@ extension Item {
         remoteInterface: RemoteInterface,
         forcedChunkSize: Int? = nil,
         progress: Progress,
-        dbManager: FilesDatabaseManager = .shared
+        dbManager: FilesDatabaseManager
     ) async -> (Item?, Error?) {
         let tempId = itemTemplate.itemIdentifier.rawValue
         

--- a/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -92,7 +92,8 @@ extension Item {
             metadata: directoryMetadata,
             parentItemIdentifier: parentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
         
         return (fpItem, nil)
@@ -208,7 +209,8 @@ extension Item {
             metadata: newMetadata,
             parentItemIdentifier: itemTemplate.parentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
         
         return (fpItem, nil)
@@ -403,7 +405,8 @@ extension Item {
             metadata: bundleRootMetadata,
             parentItemIdentifier: rootItem.parentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
     }
 
@@ -555,7 +558,8 @@ extension Item {
                     metadata: itemMetadata,
                     parentItemIdentifier: parentItemIdentifier,
                     account: account,
-                    remoteInterface: remoteInterface
+                    remoteInterface: remoteInterface,
+                    dbManager: dbManager
                 )
             }
 

--- a/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -19,7 +19,7 @@ public extension Item {
     func delete(
         trashing: Bool = false,
         domain: NSFileProviderDomain? = nil,
-        dbManager: FilesDatabaseManager = .shared
+        dbManager: FilesDatabaseManager
     ) async -> Error? {
         let serverFileNameUrl = metadata.serverUrl + "/" + metadata.fileName
         guard serverFileNameUrl != "" else {

--- a/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
@@ -128,7 +128,7 @@ public extension Item {
     func fetchContents(
         domain: NSFileProviderDomain? = nil,
         progress: Progress = .init(),
-        dbManager: FilesDatabaseManager = .shared
+        dbManager: FilesDatabaseManager
     ) async -> (URL?, Item?, Error?) {
         let ocId = itemIdentifier.rawValue
         let serverUrlFileName = metadata.serverUrl + "/" + metadata.fileName

--- a/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
@@ -267,7 +267,8 @@ public extension Item {
             metadata: updatedMetadata,
             parentItemIdentifier: parentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
 
         return (localPath, fpItem, nil)

--- a/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -18,7 +18,7 @@ public extension Item {
         newParentItemIdentifier: NSFileProviderItemIdentifier,
         newParentItemRemotePath: String,
         domain: NSFileProviderDomain? = nil,
-        dbManager: FilesDatabaseManager = .shared
+        dbManager: FilesDatabaseManager
     ) async -> (Item?, Error?) {
         let ocId = itemIdentifier.rawValue
         let isFolder = contentType.conforms(to: .directory)
@@ -820,7 +820,7 @@ public extension Item {
         domain: NSFileProviderDomain? = nil,
         forcedChunkSize: Int? = nil,
         progress: Progress = .init(),
-        dbManager: FilesDatabaseManager = .shared
+        dbManager: FilesDatabaseManager
     ) async -> (Item?, Error?) {
         var modifiedItem = self
 

--- a/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -84,7 +84,8 @@ public extension Item {
             metadata: newMetadata,
             parentItemIdentifier: newParentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
         return (modifiedItem, nil)
     }
@@ -204,7 +205,8 @@ public extension Item {
             metadata: newMetadata,
             parentItemIdentifier: parentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
         return (modifiedItem, nil)
     }
@@ -501,7 +503,8 @@ public extension Item {
             metadata: bundleRootMetadata,
             parentItemIdentifier: parentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
     }
 
@@ -539,7 +542,8 @@ public extension Item {
             metadata: dirtyMetadata,
             parentItemIdentifier: .trashContainer,
             account: account,
-            remoteInterface: modifiedItem.remoteInterface
+            remoteInterface: modifiedItem.remoteInterface,
+            dbManager: dbManager
         )
 
         // The server may have renamed the trashed file so we need to scan the entire trash
@@ -599,7 +603,8 @@ public extension Item {
             metadata: postDeleteMetadata,
             parentItemIdentifier: .trashContainer,
             account: account,
-            remoteInterface: modifiedItem.remoteInterface
+            remoteInterface: modifiedItem.remoteInterface,
+            dbManager: dbManager
         )
 
         // Now we can directly update info on the child items
@@ -685,7 +690,8 @@ public extension Item {
                 metadata: restoredItemMetadata,
                 parentItemIdentifier: parentItemIdentifier,
                 account: account,
-                remoteInterface: modifiedItem.remoteInterface
+                remoteInterface: modifiedItem.remoteInterface,
+                dbManager: dbManager
             ), nil)
         }
 

--- a/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -23,8 +23,7 @@ public class Item: NSObject, NSFileProviderItem {
         case uploadError
     }
 
-    lazy var dbManager: FilesDatabaseManager = .shared
-
+    public let dbManager: FilesDatabaseManager
     public let metadata: SendableItemMetadata
     public let parentItemIdentifier: NSFileProviderItemIdentifier
     public let account: Account
@@ -188,7 +187,11 @@ public class Item: NSObject, NSFileProviderItem {
         #endif
     }
 
-    public static func rootContainer(account: Account, remoteInterface: RemoteInterface) -> Item {
+    public static func rootContainer(
+        account: Account,
+        remoteInterface: RemoteInterface,
+        dbManager: FilesDatabaseManager
+    ) -> Item {
         let metadata = SendableItemMetadata(
             ocId: NSFileProviderItemIdentifier.rootContainer.rawValue,
             account: account.ncKitAccount,
@@ -219,11 +222,16 @@ public class Item: NSObject, NSFileProviderItem {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
     }
 
-    public static func trashContainer(remoteInterface: RemoteInterface, account: Account) -> Item {
+    public static func trashContainer(
+        remoteInterface: RemoteInterface,
+        account: Account,
+        dbManager: FilesDatabaseManager
+    ) -> Item {
         let metadata = SendableItemMetadata(
             ocId: NSFileProviderItemIdentifier.trashContainer.rawValue,
             account: account.ncKitAccount,
@@ -253,7 +261,8 @@ public class Item: NSObject, NSFileProviderItem {
             metadata: metadata,
             parentItemIdentifier: .trashContainer,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
     }
 
@@ -263,12 +272,14 @@ public class Item: NSObject, NSFileProviderItem {
         metadata: SendableItemMetadata,
         parentItemIdentifier: NSFileProviderItemIdentifier,
         account: Account,
-        remoteInterface: RemoteInterface
+        remoteInterface: RemoteInterface,
+        dbManager: FilesDatabaseManager
     ) {
         self.metadata = metadata
         self.parentItemIdentifier = parentItemIdentifier
         self.account = account
         self.remoteInterface = remoteInterface
+        self.dbManager = dbManager
         super.init()
     }
 
@@ -276,14 +287,18 @@ public class Item: NSObject, NSFileProviderItem {
         identifier: NSFileProviderItemIdentifier,
         account: Account,
         remoteInterface: RemoteInterface,
-        dbManager: FilesDatabaseManager = .shared
+        dbManager: FilesDatabaseManager
     ) -> Item? {
         // resolve the given identifier to a record in the model
         guard identifier != .rootContainer else {
-            return Item.rootContainer(account: account, remoteInterface: remoteInterface)
+            return Item.rootContainer(
+                account: account, remoteInterface: remoteInterface, dbManager: dbManager
+            )
         }
         guard identifier != .trashContainer else {
-            return Item.trashContainer(remoteInterface: remoteInterface, account: account)
+            return Item.trashContainer(
+                remoteInterface: remoteInterface, account: account, dbManager: dbManager
+            )
         }
 
         guard let metadata = dbManager.itemMetadataFromFileProviderItemIdentifier(identifier) else {
@@ -302,7 +317,8 @@ public class Item: NSObject, NSFileProviderItem {
             metadata: metadata,
             parentItemIdentifier: parentItemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         )
     }
 }

--- a/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata+Array.swift
+++ b/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata+Array.swift
@@ -35,7 +35,8 @@ extension Array<SendableItemMetadata> {
                     metadata: itemMetadata,
                     parentItemIdentifier: parentItemIdentifier,
                     account: account,
-                    remoteInterface: remoteInterface
+                    remoteInterface: remoteInterface,
+                    dbManager: dbManager
                 )
                 logger.debug(
                     """

--- a/Sources/NextcloudFileProviderKit/Utilities/ThumbnailFetching.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/ThumbnailFetching.swift
@@ -17,6 +17,7 @@ public func fetchThumbnails(
     requestedSize size: CGSize,
     account: Account,
     usingRemoteInterface remoteInterface: RemoteInterface,
+    andDatabase dbManager: FilesDatabaseManager,
     perThumbnailCompletionHandler: @escaping (
         NSFileProviderItemIdentifier,
         Data?,
@@ -38,7 +39,8 @@ public func fetchThumbnails(
         guard let item = Item.storedItem(
             identifier: itemIdentifier,
             account: account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
         ) else {
             logger.error(
                 """

--- a/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -22,7 +22,7 @@ func upload(
     withAccount account: Account,
     inChunksSized chunkSize: Int? = nil,
     usingChunkUploadId chunkUploadId: String? = UUID().uuidString,
-    dbManager: FilesDatabaseManager = .shared,
+    dbManager: FilesDatabaseManager,
     creationDate: Date? = nil,
     modificationDate: Date? = nil,
     options: NKRequestOptions = .init(queue: .global(qos: .utility)),

--- a/Tests/Interface/MockEnumerator.swift
+++ b/Tests/Interface/MockEnumerator.swift
@@ -36,7 +36,8 @@ public class MockEnumerator: NSObject, NSFileProviderEnumerator {
                 metadata: item,
                 parentItemIdentifier: parentItemIdentifier,
                 account: account,
-                remoteInterface: remoteInterface
+                remoteInterface: remoteInterface,
+                dbManager: dbManager
             )
             items.append(item)
         }

--- a/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -28,7 +28,9 @@ final class EnumeratorTests: XCTestCase {
     var remoteTrashItemB: MockRemoteItem!
     var remoteTrashItemC: MockRemoteItem!
 
-    static let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -171,7 +171,6 @@ final class EnumeratorTests: XCTestCase {
                 dbManager: Self.dbManager
             )
         )
-        storedFolderItem.dbManager = Self.dbManager
         XCTAssertEqual(storedFolderItem.itemIdentifier.rawValue, remoteFolder.identifier)
         XCTAssertEqual(storedFolderItem.filename, remoteFolder.name)
         XCTAssertEqual(storedFolderItem.parentItemIdentifier.rawValue, rootItem.identifier)
@@ -325,7 +324,6 @@ final class EnumeratorTests: XCTestCase {
                 dbManager: Self.dbManager
             )
         )
-        storedFolderItem.dbManager = Self.dbManager
         XCTAssertEqual(dbFolderMetadata.etag, remoteFolder.versionIdentifier)
         XCTAssertNotEqual(dbFolderMetadata.etag, oldEtag)
         XCTAssertEqual(storedFolderItem.childItemCount?.intValue, remoteFolder.children.count)
@@ -462,7 +460,6 @@ final class EnumeratorTests: XCTestCase {
                 dbManager: Self.dbManager
             )
         )
-        storedFolderItem.dbManager = Self.dbManager
 
         let retrievedItemA = try XCTUnwrap(observer.changedItems.first(
             where: { $0.itemIdentifier.rawValue == remoteItemA.identifier }
@@ -553,7 +550,6 @@ final class EnumeratorTests: XCTestCase {
                 dbManager: Self.dbManager
             )
         )
-        storedItemA.dbManager = Self.dbManager
         XCTAssertEqual(storedItemA.itemIdentifier.rawValue, remoteItemA.identifier)
         XCTAssertEqual(storedItemA.filename, remoteItemA.name)
         XCTAssertEqual(storedItemA.parentItemIdentifier.rawValue, rootItem.identifier)
@@ -564,10 +560,9 @@ final class EnumeratorTests: XCTestCase {
         )
 
         let storedRootItem = Item.rootContainer(
-            account: Self.account, remoteInterface: remoteInterface
+            account: Self.account, remoteInterface: remoteInterface, dbManager: Self.dbManager
         )
         print(storedRootItem.metadata.serverUrl)
-        storedRootItem.dbManager = Self.dbManager
         XCTAssertEqual(storedRootItem.childItemCount?.intValue, 3) // All items
 
         let storedFolder = try XCTUnwrap(
@@ -578,7 +573,6 @@ final class EnumeratorTests: XCTestCase {
                 dbManager: Self.dbManager
             )
         )
-        storedFolder.dbManager = Self.dbManager
         XCTAssertEqual(storedFolder.childItemCount?.intValue, remoteFolder.children.count)
     }
 
@@ -710,7 +704,6 @@ final class EnumeratorTests: XCTestCase {
                 dbManager: Self.dbManager
             )
         )
-        storedItemA.dbManager = Self.dbManager
         XCTAssertEqual(storedItemA.itemIdentifier.rawValue, remoteItemA.identifier)
         XCTAssertNotEqual(storedItemA.filename, remoteItemA.name)
         XCTAssertFalse(storedItemA.filename.isEmpty)

--- a/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -16,7 +16,9 @@ final class FilesDatabaseManagerTests: XCTestCase {
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
 
-    static let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -19,7 +19,9 @@ final class ItemCreateTests: XCTestCase {
     )
 
     var rootItem: MockRemoteItem!
-    static let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -44,7 +44,8 @@ final class ItemCreateTests: XCTestCase {
             metadata: folderItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let (createdItemMaybe, error) = await Item.create(
             basedOn: folderItemTemplate,
@@ -92,7 +93,8 @@ final class ItemCreateTests: XCTestCase {
             metadata: fileItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let (createdItemMaybe, error) = await Item.create(
             basedOn: fileItemTemplate,
@@ -139,7 +141,8 @@ final class ItemCreateTests: XCTestCase {
             metadata: folderItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (createdFolderItemMaybe, folderError) = await Item.create(
@@ -165,7 +168,8 @@ final class ItemCreateTests: XCTestCase {
             metadata: fileItemMetadata,
             parentItemIdentifier: createdFolderItem.itemIdentifier,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let tempUrl = FileManager.default.temporaryDirectory.appendingPathComponent("file")
@@ -283,7 +287,8 @@ final class ItemCreateTests: XCTestCase {
             metadata: bundleItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         // TODO: Add fail test with no contents
@@ -358,7 +363,8 @@ final class ItemCreateTests: XCTestCase {
             metadata: fileItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let (createdItemMaybe, error) = await Item.create(
             basedOn: fileItemTemplate,
@@ -446,7 +452,8 @@ final class ItemCreateTests: XCTestCase {
             metadata: fileItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let (createdItemMaybe, error) = await Item.create(
             basedOn: fileItemTemplate,

--- a/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -18,7 +18,9 @@ final class ItemDeleteTests: XCTestCase {
     )
     lazy var rootItem = MockRemoteItem.rootItem(account: Self.account)
     lazy var rootTrashItem = MockRemoteItem.rootTrashItem(account: Self.account)
-    static let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -55,7 +55,8 @@ final class ItemDeleteTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (error) = await item.delete(dbManager: Self.dbManager)
@@ -105,7 +106,8 @@ final class ItemDeleteTests: XCTestCase {
             metadata: folderMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (error) = await folder.delete(dbManager: Self.dbManager)
@@ -143,7 +145,8 @@ final class ItemDeleteTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (error) = await item.delete(trashing: true, dbManager: Self.dbManager)

--- a/Tests/NextcloudFileProviderKitTests/ItemFetchTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemFetchTests.swift
@@ -18,7 +18,9 @@ final class ItemFetchTests: XCTestCase {
     )
 
     lazy var rootItem = MockRemoteItem.rootItem(account: Self.account)
-    static let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     override func setUp() {
         super.setUp()
@@ -177,7 +179,6 @@ final class ItemFetchTests: XCTestCase {
         let fetchedItem = try XCTUnwrap(fetchedItemMaybe)
 
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: directoryMetadata.ocId))
-
 
         XCTAssertEqual(fetchedItem.itemIdentifier, item.itemIdentifier)
         XCTAssertEqual(fetchedItem.filename, item.filename)

--- a/Tests/NextcloudFileProviderKitTests/ItemFetchTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemFetchTests.swift
@@ -53,7 +53,8 @@ final class ItemFetchTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (localPathMaybe, fetchedItemMaybe, error) = await item.fetchContents(
@@ -65,8 +66,6 @@ final class ItemFetchTests: XCTestCase {
         let contents = try Data(contentsOf: localPath)
 
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: itemMetadata.ocId))
-
-        fetchedItem.dbManager = Self.dbManager
 
         XCTAssertEqual(contents, remoteItem.data)
         XCTAssertTrue(fetchedItem.isDownloaded)
@@ -167,9 +166,9 @@ final class ItemFetchTests: XCTestCase {
             metadata: directoryMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        item.dbManager = Self.dbManager
 
         let (localPathMaybe, fetchedItemMaybe, error) =
             await item.fetchContents(dbManager: Self.dbManager)
@@ -179,7 +178,6 @@ final class ItemFetchTests: XCTestCase {
 
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: directoryMetadata.ocId))
 
-        fetchedItem.dbManager = Self.dbManager
 
         XCTAssertEqual(fetchedItem.itemIdentifier, item.itemIdentifier)
         XCTAssertEqual(fetchedItem.filename, item.filename)

--- a/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -27,7 +27,9 @@ final class ItemModifyTests: XCTestCase {
     var remoteTrashFolder: MockRemoteItem!
     var remoteTrashFolderChildItem: MockRemoteItem!
 
-    static let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -124,16 +124,17 @@ final class ItemModifyTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let targetItem = Item(
             metadata: targetItemMetadata,
             parentItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        targetItem.dbManager = Self.dbManager
 
         let (modifiedItemMaybe, error) = await item.modify(
             itemTarget: targetItem,
@@ -205,17 +206,17 @@ final class ItemModifyTests: XCTestCase {
             metadata: folderMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        folderItem.dbManager = Self.dbManager
 
         let targetFolderItem = Item(
             metadata: modifiedFolderMetadata,
             parentItemIdentifier: .init(remoteFolderB.identifier),
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        targetFolderItem.dbManager = Self.dbManager
 
         let (modifiedFolderMaybe, error) = await folderItem.modify(
             itemTarget: targetFolderItem,
@@ -475,9 +476,9 @@ final class ItemModifyTests: XCTestCase {
             metadata: bundleItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        bundleItem.dbManager = Self.dbManager
 
         let fm = FileManager.default
         let tempUrl = fm.temporaryDirectory.appendingPathComponent(keynoteBundleFilename)
@@ -549,9 +550,9 @@ final class ItemModifyTests: XCTestCase {
             metadata: targetBundleMetadata,
             parentItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        targetItem.dbManager = Self.dbManager
 
         let (modifiedItemMaybe, error) = await bundleItem.modify(
             itemTarget: targetItem,
@@ -620,16 +621,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let trashItem = Item(
             metadata: itemMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-
-        item.dbManager = Self.dbManager
 
         let (trashedItemMaybe, error) = await item.modify(
             itemTarget: trashItem,
@@ -683,16 +684,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let trashItem = Item(
             metadata: renamedItemMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-
-        item.dbManager = Self.dbManager
 
         let (trashedItemMaybe, error) = await item.modify(
             itemTarget: trashItem,
@@ -762,16 +763,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: folderMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let trashFolderItem = Item(
             metadata: folderMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-
-        folderItem.dbManager = Self.dbManager
 
         let (trashedFolderItemMaybe, error) = await folderItem.modify(
             itemTarget: trashFolderItem,
@@ -858,16 +859,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: folderMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let trashFolderItem = Item(
             metadata: renamedFolderMetadata, // Test rename first and then trash
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-
-        folderItem.dbManager = Self.dbManager
 
         let (trashedFolderItemMaybe, error) = await folderItem.modify(
             itemTarget: trashFolderItem,
@@ -922,16 +923,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
         let trashItem = Item(
             metadata: itemMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-
-        item.dbManager = Self.dbManager
 
         let (trashedItemMaybe, trashError) = await item.modify(
             itemTarget: trashItem,
@@ -941,7 +942,6 @@ final class ItemModifyTests: XCTestCase {
         )
         XCTAssertNil(trashError)
         let trashedItem = try XCTUnwrap(trashedItemMaybe)
-        trashedItem.dbManager = Self.dbManager
         XCTAssertEqual(trashedItem.parentItemIdentifier, .trashContainer)
 
         let (untrashedItemMaybe, untrashError) = await trashedItem.modify(
@@ -968,15 +968,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: trashItemMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        trashItem.dbManager = Self.dbManager
 
         let untrashedTargetItem = Item(
             metadata: trashItemMetadata,
             parentItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (untrashedItemMaybe, untrashError) = await trashItem.modify(
@@ -987,7 +988,6 @@ final class ItemModifyTests: XCTestCase {
         )
         XCTAssertNil(untrashError)
         let untrashedItem = try XCTUnwrap(untrashedItemMaybe)
-        untrashedItem.dbManager = Self.dbManager
         XCTAssertEqual(untrashedItem.parentItemIdentifier, .init(remoteFolder.identifier))
     }
 
@@ -1018,15 +1018,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: trashItemMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        trashItem.dbManager = Self.dbManager
 
         let targetItem = Item(
             metadata: targetItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (modifiedUntrashedItemMaybe, error) = await trashItem.modify(
@@ -1038,7 +1039,6 @@ final class ItemModifyTests: XCTestCase {
         XCTAssertNil(error)
         
         let modifiedUntrashedItem = try XCTUnwrap(modifiedUntrashedItemMaybe)
-        modifiedUntrashedItem.dbManager = Self.dbManager
 
         XCTAssertEqual(modifiedUntrashedItem.parentItemIdentifier, .rootContainer)
         XCTAssertEqual(modifiedUntrashedItem.itemIdentifier, targetItem.itemIdentifier)
@@ -1067,15 +1067,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: trashItemMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        trashItem.dbManager = Self.dbManager
 
         let untrashedTargetItem = Item(
             metadata: trashItemMetadata,
             parentItemIdentifier: .init(rootItem.identifier),
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (untrashedItemMaybe, untrashError) = await trashItem.modify(
@@ -1086,7 +1087,6 @@ final class ItemModifyTests: XCTestCase {
         )
         XCTAssertNil(untrashError)
         let untrashedItem = try XCTUnwrap(untrashedItemMaybe)
-        untrashedItem.dbManager = Self.dbManager
         XCTAssertEqual(untrashedItem.itemIdentifier, trashItem.itemIdentifier)
         XCTAssertEqual(untrashedItem.parentItemIdentifier, .init(rootItem.identifier))
     }
@@ -1104,15 +1104,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: trashFolderMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        trashedFolderItem.dbManager = Self.dbManager
 
         let untrashedTargetItem = Item(
             metadata: trashFolderMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (untrashedFolderItemMaybe, untrashError) = await trashedFolderItem.modify(
@@ -1123,7 +1124,6 @@ final class ItemModifyTests: XCTestCase {
         )
         XCTAssertNil(untrashError)
         let untrashedItem = try XCTUnwrap(untrashedFolderItemMaybe)
-        untrashedItem.dbManager = Self.dbManager
         XCTAssertEqual(untrashedItem.parentItemIdentifier, .rootContainer)
         XCTAssertEqual(remoteTrashFolder.children.count, 1)
         XCTAssertTrue(remoteTrashFolder.remotePath.hasPrefix(Self.account.davFilesUrl))
@@ -1160,15 +1160,16 @@ final class ItemModifyTests: XCTestCase {
             metadata: trashFolderMetadata,
             parentItemIdentifier: .trashContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        trashedFolderItem.dbManager = Self.dbManager
 
         let untrashedTargetItem = Item(
             metadata: renamedTrashFolderMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let (untrashedFolderItemMaybe, untrashError) = await trashedFolderItem.modify(
@@ -1179,7 +1180,6 @@ final class ItemModifyTests: XCTestCase {
         )
         XCTAssertNil(untrashError)
         let untrashedFolderItem = try XCTUnwrap(untrashedFolderItemMaybe)
-        untrashedFolderItem.dbManager = Self.dbManager
         XCTAssertEqual(untrashedFolderItem.parentItemIdentifier, .rootContainer)
         XCTAssertEqual(untrashedFolderItem.filename, renamedTrashFolderMetadata.fileName)
         XCTAssertEqual(remoteTrashFolder.children.count, 1)
@@ -1216,16 +1216,17 @@ final class ItemModifyTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let targetItem = Item(
             metadata: targetItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        targetItem.dbManager = Self.dbManager
 
         let (modifiedItemMaybe, error) = await item.modify(
             itemTarget: targetItem,
@@ -1289,16 +1290,17 @@ final class ItemModifyTests: XCTestCase {
             metadata: itemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
 
         let targetItem = Item(
             metadata: targetItemMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: remoteInterface
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
         )
-        targetItem.dbManager = Self.dbManager
 
         let (modifiedItemMaybe, error) = await item.modify(
             itemTarget: targetItem,

--- a/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -29,7 +29,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
         XCTAssertEqual(item.contentType, UTType.text)
     }
@@ -45,7 +46,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
         XCTAssertEqual(item.contentType, UTType.pdf)
     }
@@ -61,7 +63,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
         XCTAssertEqual(item.contentType, UTType.folder)
     }
@@ -78,7 +81,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
         XCTAssertEqual(item.contentType, UTType.package)
     }
@@ -95,7 +99,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
         XCTAssertEqual(item.contentType, UTType.bundle)
     }
@@ -112,7 +117,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
         XCTAssertEqual(item.contentType, UTType.folder)
     }
@@ -129,7 +135,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
         XCTAssertTrue(item.contentType.conforms(to: .bundle))
     }
@@ -149,7 +156,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
 
         XCTAssertNotNil(item.userInfo?["locked"])
@@ -172,7 +180,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
 
         XCTAssertNil(item.userInfo?["locked"])
@@ -193,7 +202,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
 
         XCTAssertNotNil(item.userInfo?["downloaded"])
@@ -214,7 +224,8 @@ final class ItemPropertyTests: XCTestCase {
             metadata: metadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
-            remoteInterface: MockRemoteInterface()
+            remoteInterface: MockRemoteInterface(),
+            dbManager: Self.dbManager
         )
 
         XCTAssertNotNil(item.userInfo?["downloaded"])

--- a/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -17,6 +17,9 @@ final class ItemPropertyTests: XCTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     func testMetadataContentType() {
         var metadata =

--- a/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
@@ -24,7 +24,9 @@ final class MaterialisedEnumerationObserverTests: XCTestCase {
     }
 
     func testMaterialisedObserver() async {
-        let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+        let dbManager = FilesDatabaseManager(
+            realmConfig: .defaultConfiguration, account: Self.account.ncKitAccount
+        )
         let remoteInterface = MockRemoteInterface()
         let expect = XCTestExpectation(description: "Enumerator")
         let observer = MaterialisedEnumerationObserver(
@@ -50,7 +52,9 @@ final class MaterialisedEnumerationObserverTests: XCTestCase {
         var itemC = SendableItemMetadata(ocId: "itemC", fileName: "itemC", account: Self.account)
         itemC.downloaded = true
 
-        let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+        let dbManager = FilesDatabaseManager(
+            realmConfig: .defaultConfiguration, account: Self.account.ncKitAccount
+        )
         dbManager.addItemMetadata(itemA)
         dbManager.addItemMetadata(itemB)
         dbManager.addItemMetadata(itemC)

--- a/Tests/NextcloudFileProviderKitTests/UploadTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/UploadTests.swift
@@ -11,8 +11,10 @@ import XCTest
 @testable import NextcloudFileProviderKit
 
 final class UploadTests: XCTestCase {
-    let account = Account(user: "user", id: "id", serverUrl: "test.cloud.com", password: "1234")
-    let dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration)
+    static let account = Account(user: "user", id: "id", serverUrl: "test.cloud.com", password: "1234")
+    static let dbManager = FilesDatabaseManager(
+        realmConfig: .defaultConfiguration, account: account.ncKitAccount
+    )
 
     override func setUp() {
         super.setUp()
@@ -26,14 +28,14 @@ final class UploadTests: XCTestCase {
         try data.write(to: fileUrl)
 
         let remoteInterface =
-            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: account))
-        let remotePath = account.davFilesUrl + "/file.txt"
+            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
+        let remotePath = Self.account.davFilesUrl + "/file.txt"
         let result = await NextcloudFileProviderKit.upload(
             fileLocatedAt: fileUrl.path,
             toRemotePath: remotePath,
             usingRemoteInterface: remoteInterface,
-            withAccount: account,
-            dbManager: dbManager
+            withAccount: Self.account,
+            dbManager: Self.dbManager
         )
 
         XCTAssertEqual(result.remoteError, .success)
@@ -50,17 +52,17 @@ final class UploadTests: XCTestCase {
         try data.write(to: fileUrl)
 
         let remoteInterface =
-            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: account))
-        let remotePath = account.davFilesUrl + "/file.txt"
+            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
+        let remotePath = Self.account.davFilesUrl + "/file.txt"
         let chunkSize = 3
         var uploadedChunks = [RemoteFileChunk]()
         let result = await NextcloudFileProviderKit.upload(
             fileLocatedAt: fileUrl.path,
             toRemotePath: remotePath,
             usingRemoteInterface: remoteInterface,
-            withAccount: account,
+            withAccount: Self.account,
             inChunksSized: chunkSize,
-            dbManager: dbManager,
+            dbManager: Self.dbManager,
             chunkUploadCompleteHandler: { uploadedChunks.append($0) }
         )
         let resultChunks = try XCTUnwrap(result.chunks)
@@ -93,7 +95,7 @@ final class UploadTests: XCTestCase {
         try data.write(to: fileUrl)
 
         let remoteInterface =
-            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: account))
+            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
         let chunkSize = 3
         let uploadUuid = UUID().uuidString
         let previousUploadedChunkNum = 1
@@ -105,7 +107,7 @@ final class UploadTests: XCTestCase {
         let previousUploadedChunks = [previousUploadedChunk]
         remoteInterface.currentChunks = [uploadUuid: previousUploadedChunks]
 
-        let db = dbManager.ncDatabase()
+        let db = Self.dbManager.ncDatabase()
         try db.write {
             db.add([
                 RemoteFileChunk(
@@ -121,16 +123,16 @@ final class UploadTests: XCTestCase {
             ])
         }
 
-        let remotePath = account.davFilesUrl + "/file.txt"
+        let remotePath = Self.account.davFilesUrl + "/file.txt"
         var uploadedChunks = [RemoteFileChunk]()
         let result = await NextcloudFileProviderKit.upload(
             fileLocatedAt: fileUrl.path,
             toRemotePath: remotePath,
             usingRemoteInterface: remoteInterface,
-            withAccount: account,
+            withAccount: Self.account,
             inChunksSized: chunkSize,
             usingChunkUploadId: uploadUuid,
-            dbManager: dbManager,
+            dbManager: Self.dbManager,
             chunkUploadCompleteHandler: { uploadedChunks.append($0) }
         )
         let resultChunks = try XCTUnwrap(result.chunks)
@@ -219,17 +221,17 @@ final class UploadTests: XCTestCase {
         try data.write(to: fileUrl)
 
         let remoteInterface =
-            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: account))
+            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
         remoteInterface.capabilities = capabilities
 
-        let remotePath = account.davFilesUrl + "/file.txt"
+        let remotePath = Self.account.davFilesUrl + "/file.txt"
         var uploadedChunks = [RemoteFileChunk]()
         let result = await NextcloudFileProviderKit.upload(
             fileLocatedAt: fileUrl.path,
             toRemotePath: remotePath,
             usingRemoteInterface: remoteInterface,
-            withAccount: account,
-            dbManager: dbManager,
+            withAccount: Self.account,
+            dbManager: Self.dbManager,
             chunkUploadCompleteHandler: { uploadedChunks.append($0) }
         )
         let resultChunks = try XCTUnwrap(result.chunks)
@@ -298,17 +300,17 @@ final class UploadTests: XCTestCase {
         try data.write(to: fileUrl)
 
         let remoteInterface =
-            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: account))
+            MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
         remoteInterface.capabilities = capabilities
 
-        let remotePath = account.davFilesUrl + "/file.txt"
+        let remotePath = Self.account.davFilesUrl + "/file.txt"
         var uploadedChunks = [RemoteFileChunk]()
         let result = await NextcloudFileProviderKit.upload(
             fileLocatedAt: fileUrl.path,
             toRemotePath: remotePath,
             usingRemoteInterface: remoteInterface,
-            withAccount: account,
-            dbManager: dbManager,
+            withAccount: Self.account,
+            dbManager: Self.dbManager,
             chunkUploadCompleteHandler: { uploadedChunks.append($0) }
         )
         let resultChunks = try XCTUnwrap(result.chunks)


### PR DESCRIPTION
This avoids crashes and concurrency issues when multiple File Provider extension processes are active