### PR TITLE
Only request capabilities once every half-hour, rather than per required action

### DIFF
--- a/Sources/NextcloudFileProviderKit/Enumeration/RemoteChangeObserver.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/RemoteChangeObserver.swift
@@ -139,7 +139,7 @@ public class RemoteChangeObserver: NSObject, NextcloudKitDelegate, URLSessionWeb
     }
 
     private func configureNotifyPush() async {
-        let (_, capabilities, _, error) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, error) = await remoteInterface.currentCapabilities(
             account: account,
             options: .init(),
             taskHandler: { task in

--- a/Sources/NextcloudFileProviderKit/Enumeration/RemoteChangeObserver.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/RemoteChangeObserver.swift
@@ -139,7 +139,7 @@ public class RemoteChangeObserver: NSObject, NextcloudKitDelegate, URLSessionWeb
     }
 
     private func configureNotifyPush() async {
-        let (_, capabilitiesData, error) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, error) = await remoteInterface.fetchCapabilities(
             account: account,
             options: .init(),
             taskHandler: { task in
@@ -165,8 +165,7 @@ public class RemoteChangeObserver: NSObject, NextcloudKitDelegate, URLSessionWeb
             return
         }
 
-        guard let capabilitiesData = capabilitiesData,
-              let capabilities = Capabilities(data: capabilitiesData),
+        guard let capabilities,
               let websocketEndpoint = capabilities.notifyPush?.endpoints?.websocket
         else {
             logger.error(

--- a/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
@@ -380,10 +380,14 @@ public class NextcloudRemoteInterface: NextcloudKit, RemoteInterface {
         account: Account,
         options: NKRequestOptions = .init(),
         taskHandler: @escaping (_ task: URLSessionTask) -> Void = { _ in }
-    ) async -> (account: String, data: Data?, error: NKError) {
+    ) async -> (account: String, capabilities: Capabilities?, data: Data?, error: NKError) {
         return await withCheckedContinuation { continuation in
             getCapabilities(account: account.ncKitAccount, options: options, taskHandler: taskHandler) { account, data, error in
-                continuation.resume(returning: (account, data?.data, error))
+                let capabilities: Capabilities? = {
+                    guard let realData = data?.data else { return nil }
+                    return Capabilities(data: realData)
+                }()
+                continuation.resume(returning: (account, capabilities, data?.data, error))
             }
         }
     }

--- a/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
@@ -7,7 +7,7 @@
 
 import Alamofire
 import FileProvider
-import Foundation
+import NextcloudCapabilitiesKit
 import NextcloudKit
 
 public class NextcloudRemoteInterface: NextcloudKit, RemoteInterface {
@@ -16,6 +16,8 @@ public class NextcloudRemoteInterface: NextcloudKit, RemoteInterface {
         get { nkCommonInstance.delegate }
         set { setup(delegate: newValue) }
     }
+
+    public var capabilities: Capabilities?
 
     public func createFolder(
         remotePath: String,

--- a/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
@@ -12,8 +12,9 @@ import NextcloudKit
 
 public class NextcloudRemoteInterface: NextcloudKit, RemoteInterface {
 
-    public func setDelegate(_ delegate: any NextcloudKitDelegate) {
-        setup(delegate: delegate)
+    public var delegate: NextcloudKitDelegate? {
+        get { nkCommonInstance.delegate }
+        set { setup(delegate: newValue) }
     }
 
     public func createFolder(

--- a/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
@@ -387,6 +387,7 @@ public class NextcloudRemoteInterface: NextcloudKit, RemoteInterface {
                     guard let realData = data?.data else { return nil }
                     return Capabilities(data: realData)
                 }()
+                self.capabilities = capabilities
                 continuation.resume(returning: (account, capabilities, data?.data, error))
             }
         }

--- a/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/NextcloudRemoteInterface.swift
@@ -10,7 +10,7 @@ import FileProvider
 import Foundation
 import NextcloudKit
 
-extension NextcloudKit: RemoteInterface {
+public class NextcloudRemoteInterface: NextcloudKit, RemoteInterface {
 
     public func setDelegate(_ delegate: any NextcloudKitDelegate) {
         setup(delegate: delegate)

--- a/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
@@ -7,7 +7,7 @@
 
 import Alamofire
 import FileProvider
-import Foundation
+import NextcloudCapabilitiesKit
 import NextcloudKit
 
 public enum EnumerateDepth: String {
@@ -23,6 +23,7 @@ public enum AuthenticationAttemptResultState: Int {
 public protocol RemoteInterface {
 
     var delegate: NextcloudKitDelegate? { get set }
+    var capabilities: Capabilities? { get set }
 
     func createFolder(
         remotePath: String,

--- a/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
@@ -22,7 +22,7 @@ public enum AuthenticationAttemptResultState: Int {
 
 public protocol RemoteInterface {
 
-    func setDelegate(_ delegate: NextcloudKitDelegate)
+    var delegate: NextcloudKitDelegate? { get set }
 
     func createFolder(
         remotePath: String,

--- a/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
@@ -155,7 +155,7 @@ public protocol RemoteInterface {
         account: Account,
         options: NKRequestOptions,
         taskHandler: @escaping (_ task: URLSessionTask) -> Void
-    ) async -> (account: String, data: Data?, error: NKError)
+    ) async -> (account: String, capabilities: Capabilities?, data: Data?, error: NKError)
 
     func fetchUserProfile(
         account: Account,

--- a/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
+++ b/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
@@ -157,6 +157,14 @@ public protocol RemoteInterface {
         taskHandler: @escaping (_ task: URLSessionTask) -> Void
     ) async -> (account: String, capabilities: Capabilities?, data: Data?, error: NKError)
 
+    // This method should result in fetches only after a certain period of time.
+    // Alternatively, it should only fetch when capabilities are guaranteed to have changed.
+    func currentCapabilities(
+        account: Account,
+        options: NKRequestOptions,
+        taskHandler: @escaping (_ task: URLSessionTask) -> Void
+    ) async -> (account: String, capabilities: Capabilities?, data: Data?, error: NKError)
+
     func fetchUserProfile(
         account: Account,
         options: NKRequestOptions,

--- a/Sources/NextcloudFileProviderKit/Item/Item+CreateLockFile.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+CreateLockFile.swift
@@ -22,7 +22,7 @@ extension Item {
         progress.totalUnitCount = 1
 
         // Lock but don't upload, do not error
-        let (_, capabilitiesData, capabilitiesError) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, capabilitiesError) = await remoteInterface.fetchCapabilities(
             account: account,
             options: .init(),
             taskHandler: { task in
@@ -36,8 +36,7 @@ extension Item {
             }
         )
         guard capabilitiesError == .success,
-              let capabilitiesData,
-              let capabilities = Capabilities(data: capabilitiesData),
+              let capabilities,
               capabilities.files?.locking != nil
         else {
             uploadLogger.info(

--- a/Sources/NextcloudFileProviderKit/Item/Item+CreateLockFile.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+CreateLockFile.swift
@@ -43,7 +43,7 @@ extension Item {
                 """
                 Received nil capabilities data.
                     Received error: \(capabilitiesError.errorDescription, privacy: .public)
-                    Capabilities data: \(capabilitiesData == nil ? "YES" : "NO", privacy: .public)
+                    Capabilities nil: \(capabilities == nil ? "YES" : "NO", privacy: .public)
                     (if capabilities are not nil the server may just not have files_lock enabled).
                     Will not proceed with locking for \(itemTemplate.filename, privacy: .public)
                 """

--- a/Sources/NextcloudFileProviderKit/Item/Item+CreateLockFile.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+CreateLockFile.swift
@@ -22,7 +22,7 @@ extension Item {
         progress.totalUnitCount = 1
 
         // Lock but don't upload, do not error
-        let (_, capabilities, _, capabilitiesError) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, capabilitiesError) = await remoteInterface.currentCapabilities(
             account: account,
             options: .init(),
             taskHandler: { task in

--- a/Sources/NextcloudFileProviderKit/Item/Item+DeleteLockFile.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+DeleteLockFile.swift
@@ -33,7 +33,7 @@ extension Item {
                 """
                 Received nil capabilities data.
                     Received error: \(capabilitiesError.errorDescription, privacy: .public)
-                    Capabilities data: \(capabilitiesData == nil ? "YES" : "NO", privacy: .public)
+                    Capabilities nil: \(capabilities == nil ? "YES" : "NO", privacy: .public)
                     (if capabilities are not nil the server may just not have files_lock enabled).
                     Will not proceed with unlocking for \(self.filename, privacy: .public)
                 """

--- a/Sources/NextcloudFileProviderKit/Item/Item+DeleteLockFile.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+DeleteLockFile.swift
@@ -12,7 +12,7 @@ extension Item {
     func deleteLockFile(
         domain: NSFileProviderDomain? = nil, dbManager: FilesDatabaseManager
     ) async -> Error? {
-        let (_, capabilitiesData, capabilitiesError) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, capabilitiesError) = await remoteInterface.fetchCapabilities(
             account: account,
             options: .init(),
             taskHandler: { task in
@@ -26,8 +26,7 @@ extension Item {
             }
         )
         guard capabilitiesError == .success,
-              let capabilitiesData,
-              let capabilities = Capabilities(data: capabilitiesData),
+              let capabilities,
               capabilities.files?.locking != nil
         else {
             uploadLogger.info(

--- a/Sources/NextcloudFileProviderKit/Item/Item+DeleteLockFile.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+DeleteLockFile.swift
@@ -12,7 +12,7 @@ extension Item {
     func deleteLockFile(
         domain: NSFileProviderDomain? = nil, dbManager: FilesDatabaseManager
     ) async -> Error? {
-        let (_, capabilities, _, capabilitiesError) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, capabilitiesError) = await remoteInterface.currentCapabilities(
             account: account,
             options: .init(),
             taskHandler: { task in

--- a/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -47,11 +47,11 @@ func upload(
             uploadLogger.info("Using provided chunkSize: \(chunkSize, privacy: .public)")
             return chunkSize
         }
-        let (_, capabilitiesData, error) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, error) = await remoteInterface.fetchCapabilities(
             account: account, options: options, taskHandler: taskHandler
         )
-        guard let capabilitiesData,
-              let capabilities = Capabilities(data: capabilitiesData),
+        guard error == .success,
+              let capabilities,
               let serverChunkSize = capabilities.files?.chunkedUpload?.maxChunkSize,
               serverChunkSize > 0
         else {

--- a/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -47,7 +47,7 @@ func upload(
             uploadLogger.info("Using provided chunkSize: \(chunkSize, privacy: .public)")
             return chunkSize
         }
-        let (_, capabilities, _, error) = await remoteInterface.fetchCapabilities(
+        let (_, capabilities, _, error) = await remoteInterface.currentCapabilities(
             account: account, options: options, taskHandler: taskHandler
         )
         guard error == .success,

--- a/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -59,7 +59,7 @@ func upload(
                 """
                 Received nil capabilities data.
                     Received error: \(error.errorDescription, privacy: .public)
-                    Capabilities data: \(capabilitiesData == nil ? "YES" : "NO", privacy: .public)
+                    Capabilities nil: \(capabilities == nil ? "YES" : "NO", privacy: .public)
                     (if capabilities are not nil the server may just not provide chunk size data).
                     Using default file chunk size: \(defaultFileChunkSize, privacy: .public)
                 """

--- a/Tests/Interface/MockRemoteInterface.swift
+++ b/Tests/Interface/MockRemoteInterface.swift
@@ -1138,8 +1138,9 @@ public class MockRemoteInterface: RemoteInterface {
         account: Account,
         options: NKRequestOptions,
         taskHandler: @escaping (URLSessionTask) -> Void
-    ) async -> (account: String, data: Data?, error: NKError) {
-        return (account.ncKitAccount, capabilities.data(using: .utf8), .success)
+    ) async -> (account: String, capabilities: Capabilities?, data: Data?, error: NKError) {
+        let capsData = capabilitiesString.data(using: .utf8)
+        return (account.ncKitAccount, Capabilities(data: capsData ?? Data()), capsData, .success)
     }
 
     public func fetchUserProfile(

--- a/Tests/Interface/MockRemoteInterface.swift
+++ b/Tests/Interface/MockRemoteInterface.swift
@@ -1140,7 +1140,12 @@ public class MockRemoteInterface: RemoteInterface {
         taskHandler: @escaping (URLSessionTask) -> Void
     ) async -> (account: String, capabilities: Capabilities?, data: Data?, error: NKError) {
         let capsData = capabilitiesString.data(using: .utf8)
-        return (account.ncKitAccount, Capabilities(data: capsData ?? Data()), capsData, .success)
+        let capabilities: Capabilities? = {
+            guard let capsData else { return nil }
+            return Capabilities(data: capsData)
+        }()
+        self.capabilities = capabilities
+        return (account.ncKitAccount, capabilities, capsData, .success)
     }
 
     public func fetchUserProfile(

--- a/Tests/Interface/MockRemoteInterface.swift
+++ b/Tests/Interface/MockRemoteInterface.swift
@@ -560,7 +560,7 @@ fileprivate let mockCapabilities = ##"""
 public class MockRemoteInterface: RemoteInterface {
     public var capabilities = mockCapabilities
     public var rootItem: MockRemoteItem?
-    public var delegate: (any NextcloudKitDelegate)?
+    public var delegate: NextcloudKitDelegate?
     public var rootTrashItem: MockRemoteItem?
     public var currentChunks: [String: [RemoteFileChunk]] = [:]
     public var completedChunkTransferSize: [String: Int64] = [:]

--- a/Tests/Interface/MockRemoteInterface.swift
+++ b/Tests/Interface/MockRemoteInterface.swift
@@ -7,6 +7,7 @@
 
 import Alamofire
 import Foundation
+import NextcloudCapabilitiesKit
 import NextcloudFileProviderKit
 import NextcloudKit
 
@@ -558,8 +559,9 @@ fileprivate let mockCapabilities = ##"""
 """##
 
 public class MockRemoteInterface: RemoteInterface {
-    public var capabilities = mockCapabilities
+    public var capabilitiesString = mockCapabilities
     public var rootItem: MockRemoteItem?
+    public var capabilities: Capabilities?
     public var delegate: NextcloudKitDelegate?
     public var rootTrashItem: MockRemoteItem?
     public var currentChunks: [String: [RemoteFileChunk]] = [:]

--- a/Tests/Interface/MockRemoteInterface.swift
+++ b/Tests/Interface/MockRemoteInterface.swift
@@ -1148,6 +1148,14 @@ public class MockRemoteInterface: RemoteInterface {
         return (account.ncKitAccount, capabilities, capsData, .success)
     }
 
+    public func currentCapabilities(
+        account: Account,
+        options: NKRequestOptions,
+        taskHandler: @escaping (URLSessionTask) -> Void
+    ) async -> (account: String, capabilities: Capabilities?, data: Data?, error: NKError) {
+        return await fetchCapabilities(account: account, options: options, taskHandler: taskHandler)
+    }
+
     public func fetchUserProfile(
         account: Account,
         options: NKRequestOptions = .init(),

--- a/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -634,9 +634,11 @@ final class ItemCreateTests: XCTestCase {
 
     func testCreateLockFileUnactionableWithoutCapabilities() async throws {
         let remoteInterface = MockRemoteInterface(rootItem: rootItem)
-        XCTAssert(remoteInterface.capabilities.contains(##""locking": "1.0","##))
-        remoteInterface.capabilities =
-            remoteInterface.capabilities.replacingOccurrences(of: ##""locking": "1.0","##, with: "")
+        XCTAssert(remoteInterface.capabilitiesString.contains(##""locking": "1.0","##))
+        remoteInterface.capabilitiesString =
+            remoteInterface.capabilitiesString.replacingOccurrences(
+                of: ##""locking": "1.0","##, with: ""
+            )
 
         // Setup remote folder and file
         let folderRemote = MockRemoteItem(

--- a/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -270,9 +270,11 @@ final class ItemDeleteTests: XCTestCase {
 
     func testDeleteLockFileWithoutCapabilitiesDoesNothing() async throws {
         let remoteInterface = MockRemoteInterface(rootItem: rootItem)
-        XCTAssert(remoteInterface.capabilities.contains(##""locking": "1.0","##))
-        remoteInterface.capabilities =
-            remoteInterface.capabilities.replacingOccurrences(of: ##""locking": "1.0","##, with: "")
+        XCTAssert(remoteInterface.capabilitiesString.contains(##""locking": "1.0","##))
+        remoteInterface.capabilitiesString =
+            remoteInterface.capabilitiesString.replacingOccurrences(
+                of: ##""locking": "1.0","##, with: ""
+            )
 
         // Setup remote folder and file
         let folderRemote = MockRemoteItem(

--- a/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverTests.swift
@@ -45,7 +45,7 @@ final class RemoteChangeObserverTests: XCTestCase {
 
     func testAuthentication() async throws {
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
 
         var authenticated = false
 
@@ -85,7 +85,7 @@ final class RemoteChangeObserverTests: XCTestCase {
         let incorrectAccount =
             Account(user: username, id: userId, serverUrl: serverUrl, password: "wrong!")
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
         remoteChangeObserver = RemoteChangeObserver(
             account: incorrectAccount,
             remoteInterface: remoteInterface,
@@ -117,7 +117,7 @@ final class RemoteChangeObserverTests: XCTestCase {
         let incorrectAccount =
             Account(user: username, id: userId, serverUrl: serverUrl, password: "wrong!")
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
         let remoteChangeObserver = RemoteChangeObserver(
             account: incorrectAccount,
             remoteInterface: remoteInterface,
@@ -142,7 +142,7 @@ final class RemoteChangeObserverTests: XCTestCase {
 
     func testChangeRecognised() async throws {
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
 
         var authenticated = false
         var notified = false
@@ -182,7 +182,7 @@ final class RemoteChangeObserverTests: XCTestCase {
 
     func testIgnoreNonFileNotifications() async throws {
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
 
         var authenticated = false
         var notified = false
@@ -225,7 +225,7 @@ final class RemoteChangeObserverTests: XCTestCase {
     func testPolling() async throws {
         var notified = false
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = ""
+        remoteInterface.capabilitiesString = ""
         let notificationInterface = MockChangeNotificationInterface()
         notificationInterface.changeHandler = { notified = true }
         remoteChangeObserver = RemoteChangeObserver(
@@ -264,7 +264,7 @@ final class RemoteChangeObserverTests: XCTestCase {
 
     func testRetryOnRemoteClose() async throws {
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
 
         var authenticated = false
 
@@ -304,7 +304,7 @@ final class RemoteChangeObserverTests: XCTestCase {
 
     func testPinging() async throws {
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
 
         var authenticated = false
 
@@ -347,7 +347,7 @@ final class RemoteChangeObserverTests: XCTestCase {
 
     func testRetryOnConnectionLoss() async throws {
         let remoteInterface = MockRemoteInterface()
-        remoteInterface.capabilities = mockCapabilities
+        remoteInterface.capabilitiesString = mockCapabilities
 
         var authenticated = false
         var notified = false

--- a/Tests/NextcloudFileProviderKitTests/UploadTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/UploadTests.swift
@@ -222,7 +222,7 @@ final class UploadTests: XCTestCase {
 
         let remoteInterface =
             MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
-        remoteInterface.capabilities = capabilities
+        remoteInterface.capabilitiesString = capabilities
 
         let remotePath = Self.account.davFilesUrl + "/file.txt"
         var uploadedChunks = [RemoteFileChunk]()
@@ -301,7 +301,7 @@ final class UploadTests: XCTestCase {
 
         let remoteInterface =
             MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
-        remoteInterface.capabilities = capabilities
+        remoteInterface.capabilitiesString = capabilities
 
         let remotePath = Self.account.davFilesUrl + "/file.txt"
         var uploadedChunks = [RemoteFileChunk]()


### PR DESCRIPTION
This specifically impacts locking-related operations