### PR TITLE
Move all enumeration pagination-related state into page data

### DIFF
--- a/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
@@ -9,11 +9,12 @@ import Alamofire
 import Foundation
 import OSLog
 
-struct EnumeratorPageResponse: Sendable {
+fileprivate let logger = Logger(subsystem: Logger.subsystem, category: "enumeratorpageresponse")
+
+struct EnumeratorPageResponse: Sendable, Codable {
     let token: String   // Required by server to serve the next page of items
     let index: Int      // Needed to calculate the offset for the next paginated request
     let total: Int?     // Total item count, provided in the first non-offset paginated response
-    let logger = Logger(subsystem: Logger.subsystem, category: "enumeratorpageresponse")
 
     init?(nkResponseData: AFDataResponse<Data>?, index: Int) {
         guard let headers = nkResponseData?.response?.allHeaderFields as? [String: String] else {

--- a/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
@@ -12,9 +12,11 @@ import OSLog
 fileprivate let logger = Logger(subsystem: Logger.subsystem, category: "enumeratorpageresponse")
 
 struct EnumeratorPageResponse: Sendable, Codable {
-    let token: String   // Required by server to serve the next page of items
+    let token: String?   // Required by server to serve the next page of items
     let index: Int      // Needed to calculate the offset for the next paginated request
     let total: Int?     // Total item count, provided in the first non-offset paginated response
+    var serverUrlQueue: [String]?
+    var nextServerUrl: String? = nil
 
     init?(nkResponseData: AFDataResponse<Data>?, index: Int) {
         guard let headers = nkResponseData?.response?.allHeaderFields as? [String: String] else {
@@ -40,6 +42,9 @@ struct EnumeratorPageResponse: Sendable, Codable {
         } else {
             total = nil
         }
+        nextServerUrl = nil
+        serverUrlQueue = nil
+        
         let totalString = total != nil ? String(total ?? -1) : "nil"
         logger.debug(
             """
@@ -51,10 +56,12 @@ struct EnumeratorPageResponse: Sendable, Codable {
         )
     }
 
-    init(nextServerUrl: String) {
+    init(nextServerUrl: String, serverUrlQueue: [String]? = nil) {
         logger.debug("Creating artificial page response with \(nextServerUrl, privacy: .public)")
-        self.token = nextServerUrl
-        self.index = -1
+        self.token = nil
+        self.index = 0
         self.total = nil
+        self.nextServerUrl = nextServerUrl
+        self.serverUrlQueue = serverUrlQueue
     }
 }

--- a/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -486,7 +486,7 @@ final class EnumeratorTests: XCTestCase {
         // --- Scenario B: Follow-up Paginated Request (isFollowUpPaginatedRequest == true) ---
 
         // 4. Act: Call readServerUrl for the second page using the received page token.
-        let followUpPage = NSFileProviderPage(initialNextPage!.token.data(using: .utf8)!)
+        let followUpPage = NSFileProviderPage(initialNextPage!.token!.data(using: .utf8)!)
         let (
             followUpMetadatas, _, _, _, finalNextPage, followUpError
         ) = await Enumerator.readServerUrl(

--- a/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -397,13 +397,10 @@ final class EnumeratorTests: XCTestCase {
         // in the root directory, then it will be called again with the URLs of the subdirectories
         // as pages. This process continues until all directories have been enumerated.
         // We can verify that all items are discovered and stored in the database.
-        let allItemIds = [
-            folder1.identifier,
-            folder2.identifier,
-            subfolder.identifier
-        ] + folder1.children.map(\.identifier)
-          + folder2.children.map(\.identifier)
-          + subfolder.children.map(\.identifier)
+        let allItemIds = rootItem.children.map(\.identifier)
+            + folder1.children.map(\.identifier)
+            + folder2.children.map(\.identifier)
+            + subfolder.children.map(\.identifier)
 
         for itemId in allItemIds {
             XCTAssertNotNil(
@@ -412,6 +409,141 @@ final class EnumeratorTests: XCTestCase {
             )
         }
         // Root should not be stored in database
+        XCTAssertNil(Self.dbManager.itemMetadata(ocId: rootItem.identifier))
+    }
+
+    func testWorkingSetPaginatedEnumerationWithEnumeratorRecreation() async throws {
+        // This test simulates the system creating a new enumerator for each subsequent page of a
+        // paginated request
+
+        // 1. Setup a more complex, nested directory structure.
+        rootItem.children = [] // Clear existing children
+
+        let folder1 = MockRemoteItem(
+            identifier: "folder1",
+            name: "folder1",
+            remotePath: Self.account.davFilesUrl + "/folder1",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        folder1.parent = rootItem
+        rootItem.children.append(folder1)
+        for i in 0..<7 {
+            let childItem = MockRemoteItem(
+                identifier: "folder1-item\(i)",
+                name: "item\(i).txt",
+                remotePath: folder1.remotePath + "/item\(i).txt",
+                account: Self.account.ncKitAccount,
+                username: Self.account.username,
+                userId: Self.account.id,
+                serverUrl: Self.account.serverUrl
+            )
+            childItem.parent = folder1
+            folder1.children.append(childItem)
+        }
+
+        let folder2 = MockRemoteItem(
+            identifier: "folder2",
+            name: "folder2",
+            remotePath: Self.account.davFilesUrl + "/folder2",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        folder2.parent = rootItem
+        rootItem.children.append(folder2)
+
+        let subfolder = MockRemoteItem(
+            identifier: "subfolder",
+            name: "subfolder",
+            remotePath: folder2.remotePath + "/subfolder",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        subfolder.parent = folder2
+        folder2.children.append(subfolder)
+        for i in 0..<3 {
+            let childItem = MockRemoteItem(
+                identifier: "subfolder-item\(i)",
+                name: "item\(i).txt",
+                remotePath: subfolder.remotePath + "/item\(i).txt",
+                account: Self.account.ncKitAccount,
+                username: Self.account.username,
+                userId: Self.account.id,
+                serverUrl: Self.account.serverUrl
+            )
+            childItem.parent = subfolder
+            subfolder.children.append(childItem)
+        }
+        for i in 0..<8 { // Add loose items to folder2
+            let childItem = MockRemoteItem(
+                identifier: "folder2-item\(i)",
+                name: "item\(i).txt",
+                remotePath: folder2.remotePath + "/item\(i).txt",
+                account: Self.account.ncKitAccount,
+                username: Self.account.username,
+                userId: Self.account.id,
+                serverUrl: Self.account.serverUrl
+            )
+            childItem.parent = folder2
+            folder2.children.append(childItem)
+        }
+
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+        let remoteInterface = MockRemoteInterface(rootItem: rootItem, pagination: true)
+        let pageSize = 5
+
+        // 2. Manually drive the pagination loop, creating a new enumerator each time.
+        var allEnumeratedItems: [NSFileProviderItem] = []
+        var currentPage: NSFileProviderPage? =
+            NSFileProviderPage.initialPageSortedByName as NSFileProviderPage
+
+        while let pageToEnumerate = currentPage {
+            currentPage = nil // Reset for the next iteration
+
+            // Create a NEW enumerator and observer for this single page request
+            let enumerator = Enumerator(
+                enumeratedItemIdentifier: .workingSet,
+                account: Self.account,
+                remoteInterface: remoteInterface,
+                dbManager: Self.dbManager,
+                pageSize: pageSize
+            )
+            let observer = MockEnumerationObserver(enumerator: enumerator)
+            try await observer.enumerateItemsPage(page: pageToEnumerate)
+            XCTAssertNil(observer.error)
+            allEnumeratedItems += observer.items
+            currentPage = observer.page
+        }
+
+        let expectedTotalItems = 1 + 7 + 1 + 8 + 1 + 3 // 21 items total
+        XCTAssertEqual(
+            allEnumeratedItems.count,
+            expectedTotalItems,
+            "The test failed, likely because the enumerator's state was lost and it did not recursively scan subdirectories."
+        )
+
+        let allItemIds = rootItem.children.map(\.identifier)
+            + folder1.children.map(\.identifier)
+            + folder2.children.map(\.identifier)
+            + subfolder.children.map(\.identifier)
+
+        // Check if the database contains all items, which it likely won't if the test fails.
+        let itemsInDB = allItemIds.compactMap { Self.dbManager.itemMetadata(ocId: $0) }
+        XCTAssertEqual(
+            itemsInDB.count,
+            expectedTotalItems,
+            "The database should contain metadata for all discovered items."
+        )
         XCTAssertNil(Self.dbManager.itemMetadata(ocId: rootItem.identifier))
     }
 


### PR DESCRIPTION
Fixes instances where the system passes page data into new enumerator instance rather than reusing existing enumerator