### PR TITLE
Implement mitigation for server returning empty pages

### DIFF
--- a/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
@@ -461,7 +461,9 @@ extension Enumerator {
                     not much we can do...
                 """
             )
-            return (nil, nil, nil, nil, nextPage, error)
+            // This is technically possible when doing a paginated request with the index too high.
+            // It's technically not an error reply.
+            return ([], nil, nil, nil, nextPage, nil)
         }
 
         // Generally speaking a PROPFIND will provide the target of the PROPFIND as the first result

--- a/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
@@ -14,7 +14,7 @@ fileprivate let logger = Logger(subsystem: Logger.subsystem, category: "enumerat
 struct EnumeratorPageResponse: Sendable, Codable {
     let token: String?   // Required by server to serve the next page of items
     let index: Int      // Needed to calculate the offset for the next paginated request
-    let total: Int?     // Total item count, provided in the first non-offset paginated response
+    var total: Int?     // Total item count, provided in the first non-offset paginated response
     var serverUrlQueue: [String]?
     var nextServerUrl: String? = nil
 

--- a/Tests/Interface/MockRemoteInterface.swift
+++ b/Tests/Interface/MockRemoteInterface.swift
@@ -567,6 +567,7 @@ public class MockRemoteInterface: RemoteInterface {
     public var completedChunkTransferSize: [String: Int64] = [:]
     public var pagination: Bool
     public var expectedEnumerationPaginationTokens: [String: String] = [:]
+    public var forceNextPageOnLastContentPage: Bool = false
 
     public init(
         rootItem: MockRemoteItem? = nil,
@@ -1080,6 +1081,10 @@ public class MockRemoteInterface: RemoteInterface {
                options.paginateToken != expectedEnumerationPaginationTokens[account.ncKitAccount]
             {
                 return (account.ncKitAccount, [], nil, .invalidData)
+            }
+            guard !forceNextPageOnLastContentPage || firstItem < files.count else {
+                let responseData = generateResponse(itemCount: files.count, finalPage: true)
+                return (account.ncKitAccount, [], responseData, .success)
             }
             let reachedEnd = firstItem + itemCount >= files.count
             let lastItem = min(firstItem + itemCount, files.count) - 1


### PR DESCRIPTION
The server can return page tokens for new pages that are in fact empty given the provided token by the client. This breaks some of our assumptions.

This fixes that