### PR TITLE
Add test verifying directories enumerated as files is server bug

### DIFF
--- a/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -1305,6 +1305,7 @@ final class EnumeratorTests: XCTestCase {
                 identifier: "folderChild\(i)",
                 name: "folderChild\(i).txt",
                 remotePath: Self.account.davFilesUrl + "folder/folderChild\(i).txt",
+                directory: i % 5 == 0,
                 account: Self.account.ncKitAccount,
                 username: Self.account.username,
                 userId: Self.account.id,
@@ -1339,6 +1340,11 @@ final class EnumeratorTests: XCTestCase {
         for item in observer.items {
             XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: item.itemIdentifier.rawValue))
         }
+        XCTAssertEqual(
+            observer.items.filter { $0.contentType?.conforms(to: .folder) ?? false }.count,
+            5
+        )
+        XCTAssertTrue(observer.items.last?.contentType?.conforms(to: .folder) ?? false)
 
         XCTAssertEqual(observer.observedPages.first, NSFileProviderPage.initialPageSortedByName as NSFileProviderPage)
         XCTAssertEqual(observer.observedPages.count, 5)


### PR DESCRIPTION
From my notes on the issue:


- Checking into bug where on second page of paginated enumeration, folders are identified as files
	- It's a server bug.

```xml
<d:multistatus
    xmlns:d="DAV:"
    xmlns:s="http://sabredav.org/ns"
    xmlns:oc="http://owncloud.org/ns"
    xmlns:nc="http://nextcloud.org/ns">
    <d:response>
        <d:href>/remote.php/dav/files/admin/</d:href>
        <d:propstat>
            <d:prop>
                <d:displayname>admin</d:displayname>
                <d:resourcetype>
                    <d:collection/>
                </d:resourcetype>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
    <d:response>
        <d:href>/remote.php/dav/files/admin/Media/</d:href>
        <d:propstat>
            <d:prop>
                <d:displayname>Media</d:displayname>
                <d:resourcetype>
                    <d:collection/>
                </d:resourcetype>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>


<d:multistatus
    xmlns:d="DAV:"
    xmlns:s="http://sabredav.org/ns"
    xmlns:oc="http://owncloud.org/ns"
    xmlns:nc="http://nextcloud.org/ns">
    <d:response>
        <d:href>/remote.php/dav/files/admin/Nextcloud_Server_Administration_Manual.pdf</d:href>
        <d:propstat>
            <d:prop>
                <d:displayname>Nextcloud_Server_Administration_Manual.pdf</d:displayname>
                <d:resourcetype/>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
    <d:response>
        <d:href>/remote.php/dav/files/admin/Templates/</d:href>
        <d:propstat>
            <d:prop>
                <d:displayname>Templates</d:displayname>
                <d:resourcetype/>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```

- First block is page 0, second block is page 1
	- The templates item is a folder. No `resourcetype` info on it.
	- NextcloudKit only sets the `directory` property on an `NKFile` to `true` if this property is present and matching `collection` for the `resourcetype` (like in the first block)
- Started work on checking for working set changes in RemoteChangeObserver

curl calls:

```
curl -X PROPFIND -H "Depth: 1" -H "X-NC-Paginate: true" -H "X-NC-Paginate-Count: 2" -u "admin:admin" -i --data '<?xml version="1.0"?>
<d:propfind xmlns:d="DAV:">
  <d:prop>
    <d:displayname /><d:resourcetype />
  </d:prop>
</d:propfind>' "nextcloud.local/remote.php/dav/files/admin/"
```

```
curl -X PROPFIND -H "Depth: 1" -H "X-NC-Paginate: true" -H "X-NC-Paginate-Count: 2"  -u "admin:admin" -i --data '<?xml version="1.0"?>
<d:propfind xmlns:d="DAV:">
  <d:prop>
    <d:displayname /><d:resourcetype />
  </d:prop>
</d:propfind>' "nextcloud.local/remote.php/dav/files/admin/"
```