### PR TITLE
Add Package.resolved to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
-# Package.resolved
+Package.resolved
 # *.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata


### PR DESCRIPTION
Because this is a library meant for consumption by other projects, not an app project.