### PR TITLE
Fixed Directory Enumeration

### DIFF
--- a/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -87,16 +87,16 @@ public extension Item {
             ))
         }
         
-        guard var (directoryMetadata, _, _) = await files.toDirectoryReadMetadatas(account: account)
-        else {
-            logger.error("Received nil directory read metadatas during conversion")
+        guard var (directory, _, _) = await files.toSendableDirectoryMetadata(account: account, directoryToRead: remotePath) else {
+            logger.error("Failed to resolve directory metadata on item conversion!")
             return (nil, NSFileProviderError(.cannotSynchronize))
         }
-        directoryMetadata.downloaded = true
-        dbManager.addItemMetadata(directoryMetadata)
+
+        directory.downloaded = true
+        dbManager.addItemMetadata(directory)
 
         let fpItem = Item(
-            metadata: directoryMetadata,
+            metadata: directory,
             parentItemIdentifier: parentItemIdentifier,
             account: account,
             remoteInterface: remoteInterface,

--- a/Tests/Interface/MockRemoteInterface.swift
+++ b/Tests/Interface/MockRemoteInterface.swift
@@ -614,6 +614,7 @@ public class MockRemoteInterface: RemoteInterface {
         }
 
         let sanitisedPath = sanitisedPath(remotePath, account: account)
+
         guard sanitisedPath != "/" else {
             return remotePath.hasPrefix(account.trashUrl) ? rootTrashItem : rootItem
         }
@@ -624,11 +625,15 @@ public class MockRemoteInterface: RemoteInterface {
 
         while pathComponents?.isEmpty == false {
             let component = pathComponents?.removeFirst()
-            guard component?.isEmpty == false,
-                  let nextNode = currentNode?.children.first(where: { $0.name == component })
-            else { return nil }
 
-            guard pathComponents?.isEmpty == false else { return nextNode } // This is the target
+            guard component?.isEmpty == false, let nextNode = currentNode?.children.first(where: { $0.name == component }) else {
+                return nil
+            }
+
+            guard pathComponents?.isEmpty == false else {
+                return nextNode // This is the target
+            }
+            
             currentNode = nextNode
         }
 
@@ -1031,12 +1036,15 @@ public class MockRemoteInterface: RemoteInterface {
         taskHandler: @escaping (URLSessionTask) -> Void = { _ in }
     ) async -> (account: String, files: [NKFile], data: AFDataResponse<Data>?, error: NKError) {
         var remotePath = remotePath
+
         if remotePath.last == "." {
             remotePath.removeLast()
         }
+
         if remotePath.last == "/" {
             remotePath.removeLast()
         }
+
         print("Enumerating \(remotePath)")
         
         // Call the enumerate call handler if it exists

--- a/Tests/Interface/MockRemoteItem.swift
+++ b/Tests/Interface/MockRemoteItem.swift
@@ -56,7 +56,7 @@ public class MockRemoteItem: Equatable {
         MockRemoteItem(
             identifier: NSFileProviderItemIdentifier.rootContainer.rawValue,
             versionIdentifier: "root",
-            name: "",
+            name: NextcloudKit.shared.nkCommonInstance.rootFileName,
             remotePath: account.davFilesUrl,
             directory: true,
             account: account.ncKitAccount,
@@ -120,7 +120,7 @@ public class MockRemoteItem: Equatable {
         let isRoot = identifier == NSFileProviderItemIdentifier.rootContainer.rawValue
         var file = NKFile()
         file.fileName = isRoot
-            ? "__NC_ROOT__"
+            ? NextcloudKit.shared.nkCommonInstance.rootFileName
             : trashbinOriginalLocation?.split(separator: "/").last?.toString() ?? name
         file.size = size
         file.date = creationDate
@@ -128,9 +128,7 @@ public class MockRemoteItem: Equatable {
         file.etag = versionIdentifier
         file.ocId = identifier
         file.fileId = identifier.replacingOccurrences(of: trashedItemIdSuffix, with: "")
-        file.serverUrl = isRoot
-            ? serverUrl + "/remote.php/dav/files/" + userId
-            : parent?.remotePath ?? remotePath
+        file.serverUrl = isRoot ? "\(serverUrl)/remote.php/dav/files/\(userId)" : parent?.remotePath ?? serverUrl
         file.account = account
         file.user = username
         file.userId = userId

--- a/Tests/InterfaceTests/MockRemoteInterfaceTests.swift
+++ b/Tests/InterfaceTests/MockRemoteInterfaceTests.swift
@@ -2,6 +2,7 @@
 //  SPDX-License-Identifier: GPL-2.0-or-later
 
 import XCTest
+import NextcloudKit
 @testable import NextcloudFileProviderKit
 @testable import NextcloudFileProviderKitMocks
 @testable import TestInterface
@@ -503,8 +504,7 @@ final class MockRemoteInterfaceTests: XCTestCase {
         let targetRootFile = result.files.first
         let expectedRoot = remoteInterface.rootItem
         XCTAssertEqual(targetRootFile?.ocId, expectedRoot?.identifier)
-        XCTAssertEqual(targetRootFile?.fileName, "__NC_ROOT__") // NextcloudKit gives the root dir this name
-        XCTAssertNotEqual(targetRootFile?.fileName, expectedRoot?.name)
+        XCTAssertEqual(targetRootFile?.fileName, NextcloudKit.shared.nkCommonInstance.rootFileName) // NextcloudKit gives the root dir this name
         XCTAssertEqual(targetRootFile?.serverUrl, "https://mock.nc.com/remote.php/dav/files/testUserId") // NextcloudKit gives the root dir this url
         XCTAssertEqual(targetRootFile?.date, expectedRoot?.creationDate)
         XCTAssertEqual(targetRootFile?.etag, expectedRoot?.versionIdentifier)

--- a/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverTests.swift
@@ -215,7 +215,7 @@ final class RemoteChangeObserverTests: NextcloudFileProviderKitTestCase {
             account: Self.account.ncKitAccount,
             username: Self.account.username,
             userId: Self.account.id,
-            serverUrl: Self.account.serverUrl
+            serverUrl: Self.account.davFilesUrl
         )
         rootItem.children.append(serverRootFile)
 
@@ -229,7 +229,7 @@ final class RemoteChangeObserverTests: NextcloudFileProviderKitTestCase {
             account: Self.account.ncKitAccount,
             username: Self.account.username,
             userId: Self.account.id,
-            serverUrl: Self.account.serverUrl
+            serverUrl: Self.account.davFilesUrl
         )
         rootItem.children.append(serverFolderA)
 
@@ -241,7 +241,7 @@ final class RemoteChangeObserverTests: NextcloudFileProviderKitTestCase {
             account: Self.account.ncKitAccount,
             username: Self.account.username,
             userId: Self.account.id,
-            serverUrl: Self.account.serverUrl
+            serverUrl: serverFolderA.remotePath
         )
         serverFolderA.children.append(newFileInA)
 
@@ -249,7 +249,10 @@ final class RemoteChangeObserverTests: NextcloudFileProviderKitTestCase {
             XCTNSNotificationExpectation(name: NotifyPushAuthenticatedNotificationName)
         let changeNotifiedExpectation = XCTestExpectation(description: "Change Notified")
         let notificationInterface = MockChangeNotificationInterface()
-        notificationInterface.changeHandler = { changeNotifiedExpectation.fulfill() }
+
+        notificationInterface.changeHandler = {
+            changeNotifiedExpectation.fulfill()
+        }
 
         remoteChangeObserver = RemoteChangeObserver(
             account: Self.account,


### PR DESCRIPTION
- Our corporate instance was a real world use case in which the retrieved metadata of a directory and its content is no longer fulfilling the previous assumption that the first item is related to the queried directory itself. Instead, it can be anywhere in the array. Hence the implementation had to be changed to detect it by other means while taking the special `__NC_ROOT__` case into consideration.
- While reading, I also applied code style changes based on conventional Swift code style.
- Further, I hope to improve clarity by renaming some symbols like `DirectoryReadConversionActor` to `DirectoryMetadataContainer` which hints its purpose a lot better in my opinion.
- Also replaced some occurrences of empty strings or `__NC_ROOT__` literals with the symbol reference to NextcloudKit.